### PR TITLE
Add support for storyboard samples

### DIFF
--- a/src/play/constants.ts
+++ b/src/play/constants.ts
@@ -141,5 +141,20 @@ export const getAllFramePaths = (element: StoryboardAnimation) => {
   return paths;
 };
 
+export const isUsingIOS = (function () {
+  var iosQuirkPresent = function () {
+      var audio = new Audio();
+
+      audio.volume = 0.5;
+      return audio.volume === 1;   // volume cannot be changed from "1" on iOS 12 and below
+  };
+
+  var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  var isAppleDevice = navigator.userAgent.includes('Macintosh');
+  var isTouchScreen = navigator.maxTouchPoints >= 1;   // true for iOS 13 (and hopefully beyond)
+
+  return isIOS || (isAppleDevice && (isTouchScreen || iosQuirkPresent()));
+})();
+
 export const isUsingFirefox = navigator.userAgent.includes("Firefox");
 export const firefoxMaxTimeBetweenUpdates = 0.1; // Time should update about once every 40ms

--- a/src/play/constants.ts
+++ b/src/play/constants.ts
@@ -140,3 +140,6 @@ export const getAllFramePaths = (element: StoryboardAnimation) => {
   }
   return paths;
 };
+
+export const isUsingFirefox = navigator.userAgent.includes("Firefox");
+export const firefoxMaxTimeBetweenUpdates = 0.1; // Time should update about once every 40ms

--- a/src/play/game/standard_game.ts
+++ b/src/play/game/standard_game.ts
@@ -7,6 +7,8 @@ import {
   OSU_PIXELS_SCREEN_SIZE,
   VIRTUAL_SCREEN,
   VIRTUAL_SCREEN_MASK,
+  isUsingFirefox,
+  firefoxMaxTimeBetweenUpdates,
 } from "../constants";
 
 import { HitObjectTimeline } from "./hitobject_timeline";
@@ -14,9 +16,6 @@ import { StoryboardLayerTimeline } from "./storyboard_timeline";
 import CursorAutoplay from "../render/standard/cursor_autoplay";
 import { LoadedBeatmap } from "../loader/util";
 import { StoryboardVideoLayer } from "../render/common/storyboard_video";
-
-const isUsingFirefox = navigator.userAgent.includes("Firefox");
-const firefoxMaxTimeBetweenUpdates = 0.1; // Time should update about once every 40ms
 
 export class StandardGame extends Container {
   private app: Application;

--- a/src/play/game/timeline.ts
+++ b/src/play/game/timeline.ts
@@ -78,6 +78,8 @@ export class Timeline<Instance> implements IUpdatable {
 export type DOTimelineInstance = DisplayObject & IUpdatable;
 
 export class DisplayObjectTimeline extends Container implements IUpdatable {
+  private timeline: Timeline<DOTimelineInstance>;
+
   public constructor(elements: TimelineElement<DOTimelineInstance>[]) {
     super();
     this.timeline = new Timeline(
@@ -103,7 +105,24 @@ export class DisplayObjectTimeline extends Container implements IUpdatable {
     this.removeChild(instance);
   };
 
-  private timeline: Timeline<DOTimelineInstance>;
+
+  public update(timeMs: number) {
+    this.timeline.update(timeMs);
+  }
+}
+
+export class AudioObjectTimeline implements IUpdatable {
+  private timeline: Timeline<IUpdatable>;
+
+  public constructor(elements: TimelineElement<IUpdatable>[]) {
+    this.timeline = new Timeline(
+      elements,
+      null,
+      null,
+      null,
+      false,
+    );
+  }
 
   public update(timeMs: number) {
     this.timeline.update(timeMs);

--- a/src/play/game/timeline.ts
+++ b/src/play/game/timeline.ts
@@ -24,15 +24,15 @@ export class Timeline<Instance> implements IUpdatable {
   private elements: TimelineElement<Instance>[];
   private activeElements = new Set<TimelineElementState<Instance>>();
 
-  private createElement: TimelineCallback<Instance>;
-  private updateElement: TimelineCallback<Instance>;
-  private destroyElement: TimelineCallback<Instance>;
+  private createElement: TimelineCallback<Instance> | null;
+  private updateElement: TimelineCallback<Instance> | null;
+  private destroyElement: TimelineCallback<Instance> | null;
 
   public constructor(
     elements: TimelineElement<Instance>[],
-    createElement: TimelineCallback<Instance>,
-    updateElement: TimelineCallback<Instance>,
-    destroyElement: TimelineCallback<Instance>,
+    createElement: TimelineCallback<Instance> | null,
+    updateElement: TimelineCallback<Instance> | null,
+    destroyElement: TimelineCallback<Instance> | null,
     allowSkippingElements: boolean
   ) {
     this.elements = elements
@@ -59,16 +59,16 @@ export class Timeline<Instance> implements IUpdatable {
           instance: nextElement.build(),
           endTimeMs: nextElement.endTimeMs,
         };
-        this.createElement(nextElementState.instance, timeMs);
+        this.createElement?.(nextElementState.instance, timeMs);
         this.activeElements.add(nextElementState);
       }
     }
 
     for (const element of this.activeElements) {
       if (timeMs < element.endTimeMs) {
-        this.updateElement(element.instance, timeMs);
+        this.updateElement?.(element.instance, timeMs);
       } else {
-        this.destroyElement(element.instance, timeMs);
+        this.destroyElement?.(element.instance, timeMs);
         this.activeElements.delete(element);
       }
     }

--- a/src/play/loader/beatmap-loader.ts
+++ b/src/play/loader/beatmap-loader.ts
@@ -1,5 +1,4 @@
 import JSZip from "jszip";
-import { Howl } from "howler";
 import {
   StoryboardAnimation,
   StoryboardSample,
@@ -20,6 +19,7 @@ import {
   getBlobMappings,
   getFileWinCompat,
   LoadedBeatmap,
+  loadSound,
   textureFromFile,
 } from "./util";
 
@@ -239,7 +239,7 @@ export const loadBeatmapStep =
             throw new Error("Audio file not found in archive");
           }
 
-          loaded.audio = new Howl({
+          loaded.audio = await loadSound({
             src: (await blobUrlFromFile(audioFile)) as string,
             html5: true,
             preload: "metadata",
@@ -247,14 +247,6 @@ export const loadBeatmapStep =
               audioFile.name.lastIndexOf(".") + 1
             ),
           });
-
-          const loadedPromise = new Promise((resolve, reject) => {
-            loaded.audio!.on("load", resolve);
-            loaded.audio!.on("loaderror", (_id, error) => reject(error));
-          });
-          loaded.audio.load();
-
-          await loadedPromise;
         },
       },
       {

--- a/src/play/loader/beatmap-loader.ts
+++ b/src/play/loader/beatmap-loader.ts
@@ -10,7 +10,7 @@ import { executeSteps, LoadCallback } from "./executor";
 import fetchProgress from "fetch-progress";
 import md5 from "blueimp-md5";
 import { StandardBeatmap, StandardRuleset } from "osu-standard-stable";
-import { getAllFramePaths } from "../constants";
+import { getAllFramePaths, isUsingIOS } from "../constants";
 import { generateAtlases } from "./atlas-loader";
 import { loadSamples } from "./sample-loader";
 import { loadVideosStep } from "./video-loader";
@@ -241,8 +241,8 @@ export const loadBeatmapStep =
 
           loaded.audio = await loadSound({
             src: (await blobUrlFromFile(audioFile)) as string,
-            html5: true,
-            preload: "metadata",
+            html5: !isUsingIOS,
+            preload: !isUsingIOS ? "metadata" : true,
             format: audioFile.name.substring(
               audioFile.name.lastIndexOf(".") + 1
             ),

--- a/src/play/loader/beatmap-loader.ts
+++ b/src/play/loader/beatmap-loader.ts
@@ -177,8 +177,9 @@ export const loadBeatmapStep =
           cb(0, "Loading Storyboard Images & Samples");
 
           const allLayers = [...loaded.storyboard.layers.values()];
-          const visibleLayers = allLayers.filter((l) => l.visibleWhenPassing);
-          const allObjects = visibleLayers.flatMap((l) => l.elements);
+          const allObjects = allLayers
+            .filter((l) => l.visibleWhenPassing && l.name !== "Video")
+            .flatMap((l) => l.elements);
 
           const allImagePaths = new Set<string>();
           const allSamplePaths = new Set<string>();

--- a/src/play/loader/beatmap-loader.ts
+++ b/src/play/loader/beatmap-loader.ts
@@ -1,6 +1,10 @@
 import JSZip from "jszip";
 import { Howl } from "howler";
-import { StoryboardAnimation, StoryboardSample, StoryboardSprite } from "osu-classes";
+import {
+  StoryboardAnimation,
+  StoryboardSample,
+  StoryboardSprite,
+} from "osu-classes";
 import { BeatmapDecoder, StoryboardDecoder } from "osu-parsers";
 import { Beatmap as BeatmapInfo } from "osu-api-v2";
 import { executeSteps, LoadCallback } from "./executor";
@@ -201,10 +205,25 @@ export const loadBeatmapStep =
           }
 
           const imageBlobs = await getBlobMappings(loaded.zip!, allImagePaths);
-          const sampleBlobs = await getBlobMappings(loaded.zip!, allSamplePaths);
-          
-          loaded.storyboardImages = await generateAtlases(imageBlobs, cb);
-          loaded.storyboardSamples = await loadSamples(sampleBlobs, cb);
+          const sampleBlobs = await getBlobMappings(
+            loaded.zip!,
+            allSamplePaths
+          );
+
+          await executeSteps(cb, [
+            {
+              weight: 5,
+              async execute(cb) {
+                loaded.storyboardImages = await generateAtlases(imageBlobs, cb);
+              },
+            },
+            {
+              weight: 1,
+              async execute(cb) {
+                loaded.storyboardSamples = await loadSamples(sampleBlobs, cb);
+              },
+            },
+          ]);
         },
       },
       {

--- a/src/play/loader/sample-loader.ts
+++ b/src/play/loader/sample-loader.ts
@@ -22,7 +22,7 @@ export async function loadSamples(
             src: URL.createObjectURL(blob),
             html5: true,
             preload: "metadata",
-            format: name.substring(name.lastIndexOf(".") + 1),
+            format: name.substring(name.lastIndexOf(".") + 1)
           });
 
           samples.set(name, howl);

--- a/src/play/loader/sample-loader.ts
+++ b/src/play/loader/sample-loader.ts
@@ -1,0 +1,37 @@
+import { executeSteps, LoadCallback } from "./executor";
+import { Howl } from "howler";
+
+export async function loadSamples(
+  input: Map<string, Blob>,
+  cb: LoadCallback
+): Promise<Map<string, Howl>> {
+  const samples = new Map<string, Howl>();
+
+  await executeSteps(cb, [
+    {
+      weight: 1,
+      async execute(cb) {
+        let decoded = 0;
+        for (const [name, blob] of input.entries()) {
+          cb(
+            decoded / input.size,
+            `Loading Samples (${decoded + 1} / ${input.size})`
+          );
+
+          const howl = new Howl({
+            src: URL.createObjectURL(blob),
+            html5: true,
+            preload: "metadata",
+            format: name.substring(name.lastIndexOf(".") + 1)
+          });
+
+          samples.set(name, howl);
+
+          decoded++;
+        }
+      },
+    },
+  ]);
+
+  return samples;
+}

--- a/src/play/loader/sample-loader.ts
+++ b/src/play/loader/sample-loader.ts
@@ -22,7 +22,7 @@ export async function loadSamples(
             src: URL.createObjectURL(blob),
             html5: true,
             preload: "metadata",
-            format: name.substring(name.lastIndexOf(".") + 1)
+            format: name.substring(name.lastIndexOf(".") + 1),
           });
 
           samples.set(name, howl);

--- a/src/play/loader/sample-loader.ts
+++ b/src/play/loader/sample-loader.ts
@@ -1,5 +1,6 @@
-import { executeSteps, LoadCallback } from "./executor";
+import { LoadCallback } from "./executor";
 import { Howl } from "howler";
+import { loadSound } from "./util";
 
 export async function loadSamples(
   input: Map<string, Blob>,
@@ -7,31 +8,23 @@ export async function loadSamples(
 ): Promise<Map<string, Howl>> {
   const samples = new Map<string, Howl>();
 
-  await executeSteps(cb, [
-    {
-      weight: 1,
-      async execute(cb) {
-        let decoded = 0;
-        for (const [name, blob] of input.entries()) {
-          cb(
-            decoded / input.size,
-            `Loading Samples (${decoded + 1} / ${input.size})`
-          );
+  let decoded = 0;
+  for (const [name, blob] of input.entries()) {
+    cb(
+      decoded / input.size,
+      `Loading Samples (${decoded + 1} / ${input.size})`
+    );
 
-          const howl = new Howl({
-            src: URL.createObjectURL(blob),
-            html5: true,
-            preload: "metadata",
-            format: name.substring(name.lastIndexOf(".") + 1)
-          });
+    const howl = await loadSound({
+      src: URL.createObjectURL(blob),
+      preload: true,
+      format: name.substring(name.lastIndexOf(".") + 1),
+    });
 
-          samples.set(name, howl);
+    samples.set(name, howl);
 
-          decoded++;
-        }
-      },
-    },
-  ]);
+    decoded++;
+  }
 
   return samples;
 }

--- a/src/play/loader/util.ts
+++ b/src/play/loader/util.ts
@@ -2,7 +2,7 @@ import JSZip from "jszip";
 import { Storyboard } from "osu-classes";
 import { StandardBeatmap } from "osu-standard-stable";
 import { BaseTexture, ImageResource, Texture } from "pixi.js";
-import { Howl } from "howler";
+import { Howl, HowlOptions } from "howler";
 
 export interface LoadedBeatmap {
   data: StandardBeatmap;
@@ -16,7 +16,7 @@ export interface LoadedBeatmap {
 }
 
 export async function getBlobMappings(
-  zip: JSZip, 
+  zip: JSZip,
   paths: string[] | Set<string>
 ): Promise<Map<string, Blob>> {
   const blobMap = new Map<string, Blob>();
@@ -97,4 +97,19 @@ export async function textureFromFile(
   const imageResource = new ImageResource(URL.createObjectURL(blob));
   await imageResource.load();
   return new Texture(new BaseTexture(imageResource));
+}
+
+export async function loadSound(options: HowlOptions) {
+  if (options.preload === undefined || options.preload === false) {
+    throw new Error("Must preload sound to use loadSound()");
+  }
+
+  const howl = new Howl(options);
+
+  return new Promise<Howl>((resolve, reject) => {
+    howl.on("load", () => resolve(howl));
+    howl.on("loaderror", (_id, errorCode) =>
+      reject(`Error loading sound (howler code ${errorCode})`)
+    );
+  });
 }

--- a/src/play/loader/util.ts
+++ b/src/play/loader/util.ts
@@ -7,11 +7,31 @@ import { Howl } from "howler";
 export interface LoadedBeatmap {
   data: StandardBeatmap;
   storyboard: Storyboard;
-  storyboardResources: Map<string, Texture>;
+  storyboardImages: Map<string, Texture>;
+  storyboardSamples: Map<string, Howl>;
   audio: Howl;
   background?: Texture;
   videoURLs: Map<string, string | null>;
   zip: JSZip;
+}
+
+export async function getBlobMappings(
+  zip: JSZip, 
+  paths: string[] | Set<string>
+): Promise<Map<string, Blob>> {
+  const blobMap = new Map<string, Blob>();
+
+  for (const filePath of paths) {
+    const file = getFileWinCompat(zip, filePath);
+
+    if (file) {
+      blobMap.set(filePath, await file.async("blob"));
+    } else {
+      console.warn(`File "${filePath}" not found in osz`);
+    }
+  }
+
+  return blobMap;
 }
 
 export function getFileWinCompat(

--- a/src/play/main.ts
+++ b/src/play/main.ts
@@ -1,5 +1,6 @@
 import "./style.scss";
 import type { Beatmap } from "osu-api-v2";
+import { Howler } from "howler";
 import Mustache from "mustache";
 import templateError from "./main_error.html?raw";
 import template from "./main_info.handlebars?raw";
@@ -52,6 +53,11 @@ declare global {
     loadingBar.style.width = `${prop * 100}%`;
     loadingText.innerText = desc;
   };
+
+  // Increase pool of unlocked audio objects.
+  // Prevents "HTML5 Audio pool exhausted" messages.
+  // TODO: Should it be done in some other way?
+  Howler.html5PoolSize = 64;
 
   updateLoadingBar(0, "downloading app");
   try {

--- a/src/play/main.ts
+++ b/src/play/main.ts
@@ -1,6 +1,5 @@
 import "./style.scss";
 import type { Beatmap } from "osu-api-v2";
-import { Howler } from "howler";
 import Mustache from "mustache";
 import templateError from "./main_error.html?raw";
 import template from "./main_info.handlebars?raw";
@@ -53,11 +52,6 @@ declare global {
     loadingBar.style.width = `${prop * 100}%`;
     loadingText.innerText = desc;
   };
-
-  // Increase pool of unlocked audio objects.
-  // Prevents "HTML5 Audio pool exhausted" messages.
-  // TODO: Should it be done in some other way?
-  Howler.html5PoolSize = 64;
 
   updateLoadingBar(0, "downloading app");
   try {

--- a/src/play/main.ts
+++ b/src/play/main.ts
@@ -48,7 +48,15 @@ declare global {
   const loadingBar = document.getElementById("loading-bar")!;
   const loadingText = document.getElementById("loading-text")!;
 
+  let _lastProp = 0;
   const updateLoadingBar = (prop: number, desc: string) => {
+    if (prop < _lastProp) {
+      console.error(
+        `Non-monotonic loading event: status decreased from ${_lastProp} (${loadingText.innerText}) to ${prop} (${desc})`
+      );
+    }
+    _lastProp = prop;
+
     loadingBar.style.width = `${prop * 100}%`;
     loadingText.innerText = desc;
   };

--- a/src/play/render/common/storyboard_animation.ts
+++ b/src/play/render/common/storyboard_animation.ts
@@ -9,20 +9,18 @@ export class DrawableStoryboardAnimation
   private frames: Texture[];
   protected startTime: number;
 
-  public constructor(
-    object: StoryboardAnimation,
-    storyboardResources: Map<string, Texture>,
-  ) {
+  constructor(object: StoryboardAnimation, textures: Map<string, Texture>) {
     super(object);
 
     this.startTime = object.startTime;
 
-    this.frames = getAllFramePaths(object).map(
-      (path) => storyboardResources.get(path) ?? Texture.EMPTY
-    );
+    this.frames = getAllFramePaths(object)
+      .map((path) => textures.get(path) ?? Texture.EMPTY);
+
     if (this.frames.findIndex((x) => x == Texture.EMPTY) >= 0) {
       console.warn("Animation missing frames");
     }
+
     this.texture = this.frames[0];
   }
 

--- a/src/play/render/common/storyboard_element.ts
+++ b/src/play/render/common/storyboard_element.ts
@@ -57,7 +57,7 @@ export abstract class DrawableStoryboardElementWithCommands
     // TODO: Triggers
     this.commandTimeline = new Timeline(
       timelineCommands.map(this.createElement),
-      () => {},
+      null,
       this.updateCommand,
       this.finalizeCommand,
       false

--- a/src/play/render/common/storyboard_sample.ts
+++ b/src/play/render/common/storyboard_sample.ts
@@ -10,7 +10,6 @@ export class PlayableStoryboardSample {
 
     if (!this.sound) return;
 
-    this.sound.once("end", () => this.sound!.unload());
     this.soundId = this.sound.play();
     this.sound.volume(object.volume / 100, this.soundId);
   }

--- a/src/play/render/common/storyboard_sample.ts
+++ b/src/play/render/common/storyboard_sample.ts
@@ -1,0 +1,16 @@
+import { Howl } from "howler";
+import { StoryboardSample } from "osu-classes";
+
+export class PlayableStoryboardSample {
+  sound: Howl | null;
+
+  constructor(object: StoryboardSample, samples: Map<string, Howl>) {
+    this.sound = samples.get(object.filePath) ?? null;
+
+    if (!this.sound) return;
+
+    this.sound.once("end", () => this.sound!.unload());
+    this.sound.volume(object.volume / 100);
+    this.sound.play();
+  }
+}

--- a/src/play/render/common/storyboard_sample.ts
+++ b/src/play/render/common/storyboard_sample.ts
@@ -2,7 +2,8 @@ import { Howl } from "howler";
 import { StoryboardSample } from "osu-classes";
 
 export class PlayableStoryboardSample {
-  sound: Howl | null;
+  declare sound: Howl | null;
+  declare soundId: number;
 
   constructor(object: StoryboardSample, samples: Map<string, Howl>) {
     this.sound = samples.get(object.filePath) ?? null;
@@ -10,7 +11,7 @@ export class PlayableStoryboardSample {
     if (!this.sound) return;
 
     this.sound.once("end", () => this.sound!.unload());
-    this.sound.volume(object.volume / 100);
-    this.sound.play();
+    this.soundId = this.sound.play();
+    this.sound.volume(object.volume / 100, this.soundId);
   }
 }

--- a/src/play/render/common/storyboard_sprite.ts
+++ b/src/play/render/common/storyboard_sprite.ts
@@ -5,12 +5,9 @@ import { DrawableStoryboardElementWithCommands } from "./storyboard_element";
 export class DrawableStoryboardSprite 
   extends DrawableStoryboardElementWithCommands<StoryboardSprite> 
 {
-  constructor(
-    object: StoryboardSprite,
-    storyboardResources: Map<string, Texture>,
-  ) {
+  constructor(object: StoryboardSprite, textures: Map<string, Texture>) {
     super(object);
-    this.texture = storyboardResources.get(object.filePath) ?? Texture.EMPTY;
+    this.texture = textures.get(object.filePath) ?? Texture.EMPTY;
     if (this.texture == Texture.EMPTY) {
       console.warn("Sprite has no texture");
     }


### PR DESCRIPTION
This should add support for storyboard samples only. Hit sounds are more complex to handle, so I'm not sure if I can add them anytime soon.

Example beatmaps: 
https://osu.ppy.sh/beatmapsets/3756#osu/22538 - uses storyboard samples for voice lines.
https://osu.ppy.sh/beatmapsets/5381#osu/26547 - uses a whole bunch of samples for everything, including custom hit object sounds.
