### PR TITLE
Render objects that start before 0 ms.

### DIFF
--- a/src/play/game/standard_game.ts
+++ b/src/play/game/standard_game.ts
@@ -105,32 +105,7 @@ export class StandardGame extends Container {
 
     app.ticker.add(this.tick, this);
 
-    this.audio.on("end", () => {
-      this.frameTimes ??= [];
-      console.log("Rendered", this.frameTimes.length, "frames");
-      this.frameTimes.sort((a, b) => a - b);
-      const Ps = [50, 90, 99, 99.9, 99.99];
-      for (const P of Ps) {
-        console.log(
-          `P${P}`,
-          this.frameTimes[
-            Math.floor((this.frameTimes.length * P) / 100)
-          ].toFixed(2)
-        );
-      }
-      console.log("min", this.frameTimes[0].toFixed(2));
-      console.log(
-        "max",
-        this.frameTimes[this.frameTimes.length - 1].toFixed(2)
-      );
-      console.log(
-        "mean",
-        (
-          this.frameTimes.reduce((a, b) => a + b) / this.frameTimes.length
-        ).toFixed(2)
-      );
-      this.frameTimes = null;
-    });
+    this.audio.on("end", () => this.stop());
   }
 
   protected tick() {
@@ -188,6 +163,35 @@ export class StandardGame extends Container {
     
     // Don't overwrite elapsed time if audio seek is 0.
     return (this.audio.seek() * 1000) || this.timeElapsedMs;
+  }
+
+  stop() {
+    this.frameTimes ??= [];
+    this.frameTimes.sort((a, b) => a - b);
+
+    const totalFrames = this.frameTimes.length;
+
+    console.log("Rendered", totalFrames, "frames");
+    
+    const Ps = [50, 90, 99, 99.9, 99.99];
+
+    for (const P of Ps) {
+      const frameTimeIndex = Math.floor((totalFrames * P) / 100);
+      const frameTime = this.frameTimes[frameTimeIndex].toFixed(2);
+
+      console.log(`P${P} ${frameTime}`);
+    }
+
+    const min = this.frameTimes[0] ?? 0;
+    const max = this.frameTimes[this.frameTimes.length - 1] ?? 0;
+    const mean = this.frameTimes.reduce((a, b) => a + b) / (totalFrames || 1);
+
+    console.log("min", min.toFixed(2));
+    console.log("max", max.toFixed(2));
+    console.log("mean", mean.toFixed(2));
+
+    this.frameTimes = null;
+    this.isAudioEnded = true;
   }
 
   destroy(options?: IDestroyOptions | boolean) {

--- a/src/play/game/standard_game.ts
+++ b/src/play/game/standard_game.ts
@@ -28,12 +28,8 @@ export class StandardGame extends Container {
   private storyboardOverlay: StoryboardLayerTimeline;
   private songProgressGraph: SongProgressGraph;
 
-  /**
-   * When audio ends it pauses itself and resets seek time to 0.
-   * There is no way to determine whether 
-   * audio has not yet begun or has already ended. 
-   */
-  private isStarted = false;
+  private isAudioStarted = false;
+  private isAudioEnded = false;
   private audio: Howl;
   private lastSeekTime = 0;
   private lastTimeUpdateMs = 0;
@@ -155,12 +151,18 @@ export class StandardGame extends Container {
   }
 
   private getTimeElapsed(): number {
-    // Audio is not started yet and we need to render storyboard elements.
-    if (this.timeElapsedMs < 0) {
+    /**
+     * Audio is not started yet or already ended. 
+     * 0 ms is the time at which audio should always start playing.
+     * When audio ends it pauses itself and resets seek time to 0.
+     * Use {@link isAudioStarted} to make sure we don't need to play the audio again.
+     */
+    if (this.timeElapsedMs < 0 || this.isAudioEnded) {
       return this.timeElapsedMs + this.app.ticker.elapsedMS;
-    } else if (!this.isStarted) {
+    } else if (!this.isAudioStarted) {
       this.audio.play();
-      this.isStarted = true;
+      this.isAudioStarted = true;
+      this.isAudioEnded = false;
     }
 
     if (isUsingFirefox) {

--- a/src/play/game/standard_game.ts
+++ b/src/play/game/standard_game.ts
@@ -28,6 +28,12 @@ export class StandardGame extends Container {
   private storyboardOverlay: StoryboardLayerTimeline;
   private songProgressGraph: SongProgressGraph;
 
+  /**
+   * When audio ends it pauses itself and resets seek time to 0.
+   * There is no way to determine whether 
+   * audio has not yet begun or has already ended. 
+   */
+  private isStarted = false;
   private audio: Howl;
   private lastSeekTime = 0;
   private lastTimeUpdateMs = 0;
@@ -150,12 +156,11 @@ export class StandardGame extends Container {
 
   private getTimeElapsed(): number {
     // Audio is not started yet and we need to render storyboard elements.
-    if (this.timeElapsedMs < 16.67) {
-      if (this.timeElapsedMs >= 0 && !this.audio.playing()) {
-        this.audio.play();
-      }
-
+    if (this.timeElapsedMs < 0) {
       return this.timeElapsedMs + this.app.ticker.elapsedMS;
+    } else if (!this.isStarted) {
+      this.audio.play();
+      this.isStarted = true;
     }
 
     if (isUsingFirefox) {

--- a/src/play/game/standard_game.ts
+++ b/src/play/game/standard_game.ts
@@ -186,7 +186,8 @@ export class StandardGame extends Container {
       return Math.max(this.timeElapsedMs, this.trueTimeElapsedMs);
     }
     
-    return this.audio.seek() * 1000;
+    // Don't overwrite elapsed time if audio seek is 0.
+    return (this.audio.seek() * 1000) || this.timeElapsedMs;
   }
 
   destroy(options?: IDestroyOptions | boolean) {

--- a/src/play/game/storyboard_timeline.ts
+++ b/src/play/game/storyboard_timeline.ts
@@ -145,9 +145,12 @@ export class StoryboardLayerTimeline extends Container {
   }
 
   private createSample(sample: StoryboardSample) {
+    const howl = this.storyboardSamples.get(sample.filePath);
+    const duration = (howl?.duration() ?? 0) * 1000;
+
     return {
       startTimeMs: sample.startTime,
-      endTimeMs: sample.startTime,
+      endTimeMs: sample.startTime + duration,
       build: () => {
         return new PlayableStoryboardSample(sample, this.storyboardSamples);
       },

--- a/src/play/game/timeline.ts
+++ b/src/play/game/timeline.ts
@@ -54,10 +54,9 @@ export class Timeline<Instance> implements IUpdatable {
     ) {
       const nextElement = this.elements[this.nextElementIndex];
 
-      const hasStarted = timeMs >= nextElement.startTimeMs;
       const hasEnded = timeMs >= nextElement.endTimeMs;
 
-      if (hasStarted && !hasEnded || !this.allowSkippingElements) {
+      if (!(hasEnded && this.allowSkippingElements)) {
         const nextElementState: TimelineElementState<Instance> = {
           instance: nextElement.build(),
           endTimeMs: nextElement.endTimeMs,

--- a/src/play/game/timeline.ts
+++ b/src/play/game/timeline.ts
@@ -54,7 +54,10 @@ export class Timeline<Instance> implements IUpdatable {
     ) {
       const nextElement = this.elements[this.nextElementIndex];
 
-      if (!this.allowSkippingElements || timeMs < nextElement.endTimeMs) {
+      const hasStarted = timeMs >= nextElement.startTimeMs;
+      const hasEnded = timeMs >= nextElement.endTimeMs;
+
+      if (hasStarted && !hasEnded || !this.allowSkippingElements) {
         const nextElementState: TimelineElementState<Instance> = {
           instance: nextElement.build(),
           endTimeMs: nextElement.endTimeMs,
@@ -120,7 +123,7 @@ export class AudioObjectTimeline implements IUpdatable {
       null,
       null,
       null,
-      false,
+      true,
     );
   }
 

--- a/src/play/render/common/video/video_player_html5.ts
+++ b/src/play/render/common/video/video_player_html5.ts
@@ -23,7 +23,15 @@ export class VideoPlayerHTML5 extends Sprite implements IUpdatable {
       },
       true
     );
-    this.video.addEventListener("ended", () => this.destroy(true));
+    this.video.addEventListener("ended", () => {
+      /**
+       * We need to empty this texture when this video ends.
+       * Otherwise Pixi will throw an error as we are trying 
+       * to update the texture using the video that is already destroyed.
+       */
+      this.texture = Texture.EMPTY;
+      this.destroy(true);
+    });
 
     this.video.src = videoUrl;
 


### PR DESCRIPTION
This also fixes some bugs related to storyboard samples. Timeline objects don't start playing if they have already ended. For example, [this](https://osu.ppy.sh/beatmapsets/5381#osu/26547) beatmap doesn't hurt your ears anymore.

Before: https://osu-js.pages.dev/play/?26547
After: https://41d9767e.kionell-osu-js.pages.dev/play/?26547